### PR TITLE
add cause property

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 class TroyError extends Error {
-  constructor(readonly originalError: unknown) {
-    super(`${originalError}`);
+  constructor(readonly originalError: unknown = 'unknown error') {
+    super(`${originalError}`, {cause: e});
     this.name = this.constructor.name;
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 class TroyError extends Error {
   constructor(readonly originalError: unknown = 'unknown error') {
-    super(`${originalError}`, {cause: e});
+    super(`${originalError}`, {cause: originalError});
     this.name = this.constructor.name;
   }
 }


### PR DESCRIPTION
- default to 'unknown error' so the error doesn't throw in corner case of error is undefined. Might be worth handling null too.
- pass the original error in as {cause} property. This helps devx a lot
![image](https://github.com/user-attachments/assets/52a5b345-8c8d-4254-8400-c1969bb483de)
